### PR TITLE
Needed to make sure that the assertion image is shown so that the metadata is also included should they upload the results to another backpack service.

### DIFF
--- a/src/components/ProgressDetails/index.jsx
+++ b/src/components/ProgressDetails/index.jsx
@@ -79,7 +79,7 @@ export default class ProgressDetails extends React.Component {
     } = this.props;
 
     const childElements = (
-      <img className={classNames("card-img-top asserted", minimal)} src={progress.badge_class.image} alt={progress.badge_class.display_name} />
+      <img className={classNames("card-img-top asserted", minimal)} src={progress.assertion.image_url} alt={progress.badge_class.display_name} />
     );
 
     return (
@@ -112,7 +112,7 @@ export default class ProgressDetails extends React.Component {
                   </div>
                   <div className="progress-details-body row w-100">
                     <div className="progress-details-image col col-3">
-                      <img src={progress.badge_class.image} alt={progress.badge_class.display_name} />
+                      <img src={progress.assertion.image_url} alt={progress.badge_class.display_name} />
                       <Button
                         children="View Backpack"
                         buttonType="primary"


### PR DESCRIPTION
Previously the badge class image was used for the ProgressDetails component. Should the learner decide to download the badge using the assertion image would allow them to verify the badge using a service like https://badgecheck.io/ or uploading to a backpack.