### PR TITLE
Added production environment values used within the `badges-frontend` application. 

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -4,6 +4,7 @@ const Merge = require('webpack-merge');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
@@ -110,6 +111,18 @@ module.exports = Merge.smart(commonConfig, {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(__dirname, '../public/index.html'),
+    }),
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'production',
+      MOCK_LMS_API: false,
+      BASE_URL: null,
+      LMS_BASE_URL: null,
+      LOGIN_URL: null,
+      LOGOUT_URL: null,
+      CSRF_TOKEN_API_PATH: null,
+      REFRESH_ACCESS_TOKEN_ENDPOINT: null,
+      ACCESS_TOKEN_COOKIE_NAME: 'edx-jwt-cookie-header-payload',
+      USER_INFO_COOKIE_NAME: 'edx-user-info',
     }),
   ],
 });


### PR DESCRIPTION
Most of these environment variables were used for the `@edx/frontend-auth` application to talk back with the LMS ReST APIs. At this time we're not using that but instead using NGINX to proxy back our requests to the LMS like `@edx/studio-frontend` is doing.

The image path for `/src/images/badgr-logo.svg` was missing so setting the `BASE_URL` variable will help with that.

For the most part these environment settings will be not set for the Hawthorn release. `MOCK_LMS_API` is used to pull in mock data from `/src/data/services/LmsApiService.js` to simulate a call to the LMS ReST API but should be set to `false` in production mode.